### PR TITLE
feat: proxy images from `cdn.nlark.com` to prevent CORS

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/nlark/*"
+to = "https://cdn.nlark.com/:splat"
+status = 200

--- a/src/lib/Clipboard.svelte
+++ b/src/lib/Clipboard.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import Icon from "@iconify/svelte";
 
-  export let content: string;
+  export let content: string | (() => string);
 
   let state = 0;
 
   let willChangeState: ReturnType<typeof setTimeout>;
 
   async function handleClick() {
-    await navigator.clipboard.writeText(content);
+    await navigator.clipboard.writeText(typeof content === "string" ? content : content());
     state = 1;
     clearTimeout(willChangeState);
     willChangeState = setTimeout(() => (state = 2), 1000);

--- a/src/lib/Marked.svelte
+++ b/src/lib/Marked.svelte
@@ -14,6 +14,8 @@
   import Clipboard from "./Clipboard.svelte";
   import { onMount } from "svelte";
 
+  markdown = markdown.replaceAll("https://cdn.nlark.com/", "/nlark/");
+
   const html = md.render(markdown);
 
   // patch code blocks at client side
@@ -44,7 +46,7 @@
 <div class="relative flex flex-row">
   <Title {title} {description} />
   <div class="absolute right-0 mx-6 mt-6 sm:mx-10 sm:mt-10">
-    <Clipboard content={markdown} />
+    <Clipboard content={() => markdown.replaceAll("/nlark/", new URL("/nlark/", location.origin).href)} />
   </div>
 </div>
 

--- a/src/routes/nlark/[...path]/+server.ts
+++ b/src/routes/nlark/[...path]/+server.ts
@@ -4,3 +4,5 @@ export const GET: RequestHandler = async ({ fetch, params: { path } }) => {
   const res = await fetch(`https://cdn.nlark.com/${path}`);
   return new Response(res.body, res);
 };
+
+export const config = { runtime: "edge" };

--- a/src/routes/nlark/[...path]/+server.ts
+++ b/src/routes/nlark/[...path]/+server.ts
@@ -1,0 +1,6 @@
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ fetch, params: { path } }) => {
+  const res = await fetch(`https://cdn.nlark.com/${path}`);
+  return new Response(res.body, res);
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/nlark/:path*",
+      "destination": "https://cdn.nlark.com/:path*"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "rewrites": [
-    {
-      "source": "/nlark/:path*",
-      "destination": "https://cdn.nlark.com/:path*"
-    }
-  ]
-}


### PR DESCRIPTION
Resolves #5

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery的总结

通过重写URL并为Vercel和Netlify部署添加服务器端处理程序，实现`cdn.nlark.com`图像的代理以防止CORS问题。增强Clipboard组件以支持动态内容生成。

新功能：
- 引入代理机制，通过应用程序提供来自`cdn.nlark.com`的图像以防止CORS问题。

增强：
- 更新Clipboard组件以接受用于动态内容生成的函数。

部署：
- 添加`vercel.json`配置，将请求从`/nlark/:path*`重写为`https://cdn.nlark.com/:path*`。
- 添加`netlify.toml`配置，将请求从`/nlark/*`重定向到`https://cdn.nlark.com/:splat`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a proxy for images from `cdn.nlark.com` to prevent CORS issues by rewriting URLs and adding server-side handlers for Vercel and Netlify deployments. Enhance the Clipboard component to support dynamic content generation.

New Features:
- Introduce a proxy mechanism to serve images from `cdn.nlark.com` through the application to prevent CORS issues.

Enhancements:
- Update the Clipboard component to accept a function for dynamic content generation.

Deployment:
- Add `vercel.json` configuration to rewrite requests to `/nlark/:path*` to `https://cdn.nlark.com/:path*`.
- Add `netlify.toml` configuration to redirect requests from `/nlark/*` to `https://cdn.nlark.com/:splat`.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->